### PR TITLE
Added support for XML attachments encoding in MIME messages

### DIFF
--- a/mimepart.pas
+++ b/mimepart.pas
@@ -337,7 +337,7 @@ type
   end;
 
 const
-  MaxMimeType = 25;
+  MaxMimeType = 26;
   MimeType: array[0..MaxMimeType, 0..2] of string =
   (
     ('AU', 'audio', 'basic'),
@@ -365,7 +365,8 @@ const
     ('TIFF', 'image', 'TIFF'),
     ('WAV', 'audio', 'x-wav'),
     ('WPD', 'application', 'Wordperfect5.1'),
-    ('ZIP', 'application', 'ZIP')
+    ('ZIP', 'application', 'ZIP'),
+    ('XML', 'application', 'xml')
     );
 
 {:Generates a unique boundary string.}


### PR DESCRIPTION
I was trying to send e-mails with XML attachments but they weren't encoded correctly on the message (some e-mail clients couldn't recognize them as XML). After some research, I wrote this solution.

Please evaluate my suggestion and add it to the repository if it looks right.