### PR TITLE
Extend TSMTPSend to allow validation of SMTP server certificates

### DIFF
--- a/ssl_openssl3.pas
+++ b/ssl_openssl3.pas
@@ -368,9 +368,13 @@ begin
       if SslCtxUsePrivateKeyASN1(EVP_PKEY_RSA, FCtx, FPrivateKey, length(FPrivateKey)) <> 1 then
         Exit;
     SSLCheck;
-    if FCertCAFile <> '' then
-      if SslCtxLoadVerifyLocations(FCtx, FCertCAFile, '') <> 1 then
+    if FCertCAFile <> '' then begin
+      if Pos('://', FCertCAFile) > 1 then begin; // we have a URI
+        if SslCtxLoadVerifyStore(FCtx, FCertCAFile) <> 1 then
+          Exit;
+      end else if SslCtxLoadVerifyLocations(FCtx, FCertCAFile, '') <> 1 then
         Exit;
+    end;
     if FPFXfile <> '' then
     begin
       try

--- a/ssl_openssl3_lib.pas
+++ b/ssl_openssl3_lib.pas
@@ -264,6 +264,7 @@ var
   procedure SslCtxSetDefaultPasswdCbUserdata(ctx: PSSL_CTX; u: SslPtr);
 //  function SslCtxLoadVerifyLocations(ctx: PSSL_CTX; const CAfile: PChar; const CApath: PChar):Integer;
   function SslCtxLoadVerifyLocations(ctx: PSSL_CTX; const CAfile: AnsiString; const CApath: AnsiString):Integer;
+  function SslCtxLoadVerifyStore(ctx: PSSL_CTX; const CAstore: AnsiString):Integer;
   function SslCtxCtrl(ctx: PSSL_CTX; cmd: integer; larg: integer; parg: SslPtr): integer;
   function SslNew(ctx: PSSL_CTX):PSSL;
   procedure SslFree(ssl: PSSL);
@@ -380,6 +381,7 @@ type
   TSslCtxSetDefaultPasswdCb = procedure(ctx: PSSL_CTX; cb: SslPtr); cdecl;
   TSslCtxSetDefaultPasswdCbUserdata = procedure(ctx: PSSL_CTX; u: SslPtr); cdecl;
   TSslCtxLoadVerifyLocations = function(ctx: PSSL_CTX; const CAfile: PAnsiChar; const CApath: PAnsiChar):Integer; cdecl;
+  TSslCtxLoadVerifyStore = function(ctx: PSSL_CTX; const CAstore: PAnsiChar):Integer; cdecl;
   TSslCtxCtrl = function(ctx: PSSL_CTX; cmd: integer; larg: integer; parg: SslPtr): integer; cdecl;
   TSslNew = function(ctx: PSSL_CTX):PSSL; cdecl;
   TSslFree = procedure(ssl: PSSL); cdecl;
@@ -482,6 +484,7 @@ var
   _SslCtxSetDefaultPasswdCb: TSslCtxSetDefaultPasswdCb = nil;
   _SslCtxSetDefaultPasswdCbUserdata: TSslCtxSetDefaultPasswdCbUserdata = nil;
   _SslCtxLoadVerifyLocations: TSslCtxLoadVerifyLocations = nil;
+  _SslCtxLoadVerifyStore: TSslCtxLoadVerifyStore = nil;
   _SslCtxCtrl: TSslCtxCtrl = nil;
   _SslNew: TSslNew = nil;
   _SslFree: TSslFree = nil;
@@ -696,6 +699,14 @@ function SslCtxLoadVerifyLocations(ctx: PSSL_CTX; const CAfile: AnsiString; cons
 begin
   if InitSSLInterface and Assigned(_SslCtxLoadVerifyLocations) then
     Result := _SslCtxLoadVerifyLocations(ctx, SslPtr(CAfile), SslPtr(CApath))
+  else
+    Result := 0;
+end;
+
+function SslCtxLoadVerifyStore(ctx: PSSL_CTX; const CAstore: AnsiString):Integer;
+begin
+  if InitSSLInterface and Assigned(_SslCtxLoadVerifyStore) then
+    Result := _SslCtxLoadVerifyStore(ctx, SslPtr(CAstore))
   else
     Result := 0;
 end;
@@ -1293,6 +1304,7 @@ begin
         _SslCtxSetDefaultPasswdCb := GetProcAddr(SSLLibHandle, 'SSL_CTX_set_default_passwd_cb');
         _SslCtxSetDefaultPasswdCbUserdata := GetProcAddr(SSLLibHandle, 'SSL_CTX_set_default_passwd_cb_userdata');
         _SslCtxLoadVerifyLocations := GetProcAddr(SSLLibHandle, 'SSL_CTX_load_verify_locations');
+        _SslCtxLoadVerifyStore := GetProcAddr(SSLLibHandle, 'SSL_CTX_load_verify_store');;
         _SslCtxCtrl := GetProcAddr(SSLLibHandle, 'SSL_CTX_ctrl');
         _SslNew := GetProcAddr(SSLLibHandle, 'SSL_new');
         _SslFree := GetProcAddr(SSLLibHandle, 'SSL_free');


### PR DESCRIPTION
Starting with Version 3.2 OpenSSL allows validating server certificates by using the store URI ``org.openssl.winstore://`` See [https://github.com/openssl/openssl/blob/master/CHANGES.md](https://github.com/openssl/openssl/blob/master/CHANGES.md#changes-between-31-and-320-23-nov-2023):

> Support for loading root certificates from the Windows certificate store has been added. The support is in the form of a store which recognises the URI string of org.openssl.winstore://. This URI scheme currently takes no arguments. This store is built by default and can be disabled using the new compile-time option no-winstore. This store is not currently used by default and must be loaded explicitly using the above store URI. It is expected to be loaded by default in the future.
> 
> _Hugo Landau_

This set of patches extends the OpenSSL V3 implementation to be able to use this URI. Also it extends TSMTPSend to be able to use this extension to be able to validate certificates by specifying the winstore-URI.